### PR TITLE
Fixed typo in README file.

### DIFF
--- a/README
+++ b/README
@@ -9,10 +9,10 @@ INSTALLATION
 
 To install this module type the following:
 
-   perl Makefile.PL
-   make
-   make test
-   make install
+   perl Build.PL
+   ./Build
+   ./Build test
+   ./Build install
 
 DEPENDENCIES
 


### PR DESCRIPTION
The module uses `Module::Build` and not `ExtUtils::MakeMaker` for building.

*[[Assigned by [pullrequest.club](https://pullrequest.club)]]*